### PR TITLE
Fix middlewares only checking for params and not for req.body

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,12 +41,12 @@ model User {
     email       String       @unique
     password    String?
     role        Role         @default(USER)
-    company     Company?     @relation(fields: [companyId], references: [id])
+    company     Company     @relation(fields: [companyId], references: [id])
     job         Job          @relation(fields: [jobId], references: [id])
     weeklyBasis WeeklyBasis? @default(h35)
     createdAt   DateTime     @default(now())
     updatedAt   DateTime     @default(now()) @updatedAt
-    companyId   String?
+    companyId   String
     jobId       String
     projects    Project[]
     records     Record[]

--- a/src/api/companies/routes.js
+++ b/src/api/companies/routes.js
@@ -34,9 +34,7 @@ const getUsers = require("./controllers/users");
 router.get("/", superadmin(), verifyCompany, getAll);
 router.post("/", superadmin(), bodyValidator(companySchema), post);
 
-router.use(verifyCompany);
-
-router.get("/:id", user(), getOne);
+router.get("/:id", user(), verifyCompany, getOne);
 router.put(
   "/:id",
   admin(),
@@ -44,8 +42,8 @@ router.put(
   bodyValidator(companySchemaEdit),
   put
 );
-router.delete("/:id", admin(), deleteCompany);
-router.get("/:id/projects", user(), getProjectsFromCompany);
-router.get("/:id/users", user(), getUsers);
+router.delete("/:id", admin(), verifyCompany, deleteCompany);
+router.get("/:id/projects", user(), verifyCompany, getProjectsFromCompany);
+router.get("/:id/users", user(), verifyCompany, getUsers);
 
 module.exports = router;

--- a/src/api/users/routes.js
+++ b/src/api/users/routes.js
@@ -1,7 +1,8 @@
 const express = require("express");
 
-const { user, superadmin } = require("../../utils/roles");
+const { user, admin, superadmin } = require("../../utils/roles");
 const bodyValidator = require("../../middlewares/bodyValidator");
+const verifyCompany = require("../../middlewares/verifyCompany");
 
 const router = express.Router();
 
@@ -40,9 +41,9 @@ const deleteUserProject = require("./controllers/deleteUserProject");
 
 router.get("/", superadmin(), getAll);
 router.get("/:id", user(), getOne);
-router.post("/", superadmin(), bodyValidator(userSchema), post);
-router.put("/:id", superadmin(), put);
-router.delete("/:id", superadmin(), deleteUser);
+router.post("/", admin(), verifyCompany, bodyValidator(userSchema), post);
+router.put("/:id", admin(), verifyCompany, put);
+router.delete("/:id", admin(), verifyCompany, deleteUser);
 router.post("/:userId/projects/:projectId", superadmin(), createUserProject);
 router.delete("/:userId/projects/:projectId", superadmin(), deleteUserProject);
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 require("dotenv").config();
 
+const bcrypt = require("bcrypt");
+
 const app = require("./app");
 const prisma = require("../prismaClient");
 
@@ -22,28 +24,28 @@ app.listen(
     });
 
     if (!user) {
-      const company = await prisma.company.create({
-        data: {
-          name: "AeViso",
-        },
-      });
+      const company = {
+        name: "AeViso",
+      };
 
-      const job = await prisma.job.create({
-        data: {
-          label: process.env.USER_JOB,
-        },
-      });
+      const job = {
+        label: process.env.USER_JOB,
+      };
 
       await prisma.user.create({
         data: {
           firstName: process.env.USER_FIRSTNAME,
           lastName: process.env.USER_LASTNAME,
           email: process.env.USER_EMAIL,
-          password: process.env.USER_PASSWORD,
-          role: "SUPERADMIN",
-          companyId: company.id,
-          jobId: job.id,
+          password: bcrypt.hashSync(process.env.USER_PASSWORD, 10),
+          role: "ADMIN",
+          job: {
+            create: job,
+          },
           weeklyBasis: "h35",
+          company: {
+            create: company,
+          },
         },
       });
 

--- a/src/middlewares/verifyCompany.js
+++ b/src/middlewares/verifyCompany.js
@@ -7,7 +7,9 @@ const verifyCompany = async (req, res, next) => {
     }
 
     const { id: _id, companyId } = req.params;
-    const id = _id || companyId;
+    const { companyId: bodyCompanyId } = req.body;
+
+    const id = _id || companyId || bodyCompanyId;
 
     const user = await prisma.user.findFirst({
       where: {

--- a/src/middlewares/verifyProject.js
+++ b/src/middlewares/verifyProject.js
@@ -7,7 +7,8 @@ const verifyProject = async (req, res, next) => {
     }
 
     const { id: _id, projectId } = req.params;
-    const id = _id || projectId;
+    const { projectId: bodyProjectId } = req.body;
+    const id = _id || projectId || bodyProjectId;
 
     const project = await prisma.project.findFirst({
       where: {


### PR DESCRIPTION
This PR fixes companies' admins being unable to create a new user for their own company. This happened because the middleware was only checking for `req.params` while the company's id is passed to `req.body` in the case of a POST, or a PUT.
The middleware now takes that into account too.

**Do not merge yet. Waiting for confirmation this works for others.**