### PR TITLE
FIX: Reorganize routes order

### DIFF
--- a/src/api/companies/controllers/users/index.js
+++ b/src/api/companies/controllers/users/index.js
@@ -1,5 +1,4 @@
 const prisma = require("../../../../../prismaClient");
-const errors = require("../../../errors");
 
 /**
  * GET /api/v1/companies/{id}/users

--- a/src/api/users/controllers/editSelf.js
+++ b/src/api/users/controllers/editSelf.js
@@ -13,8 +13,6 @@ const editSelf = async (req, res, next) => {
     const { email: oldEmail } = req.user;
     const { firstName, lastName, email: newEmail } = req.body;
 
-    console.log(oldEmail, newEmail);
-
     const user = await prisma.user.update({
       where: {
         email: oldEmail,
@@ -27,6 +25,8 @@ const editSelf = async (req, res, next) => {
     });
 
     delete user.password;
+
+    req.user.email = newEmail;
 
     res.status(200).json(user);
   } catch (e) {

--- a/src/api/users/controllers/editSelf.js
+++ b/src/api/users/controllers/editSelf.js
@@ -13,6 +13,8 @@ const editSelf = async (req, res, next) => {
     const { email: oldEmail } = req.user;
     const { firstName, lastName, email: newEmail } = req.body;
 
+    console.log(oldEmail, newEmail);
+
     const user = await prisma.user.update({
       where: {
         email: oldEmail,

--- a/src/api/users/controllers/put.js
+++ b/src/api/users/controllers/put.js
@@ -12,8 +12,16 @@ const put = async (req, res, next) => {
   let company;
   let job;
   const { id } = req.params;
-  const { firstName, lastName, email, role, weeklyBasis, companyId, jobId } =
-    req.body;
+  const {
+    firstName,
+    lastName,
+    email,
+    role,
+    password,
+    weeklyBasis,
+    companyId,
+    jobId,
+  } = req.body;
 
   try {
     if (companyId) {
@@ -43,6 +51,7 @@ const put = async (req, res, next) => {
         firstName,
         lastName,
         email,
+        password,
         role,
         weeklyBasis,
         company,

--- a/src/api/users/routes.js
+++ b/src/api/users/routes.js
@@ -52,10 +52,10 @@ router.get("/:id/projects", getProjects);
 router.get("/:id/records", getRecords);
 
 router.post("/", admin(), verifyCompany, bodyValidator(userSchema), post);
-router.put("/:id", admin(), verifyUserCompany, put);
-router.delete("/:id", admin(), verifyUserCompany, deleteUser);
 router.put("/self", user(), editSelf);
 router.put("/self/password", user(), editPassword);
+router.put("/:id", admin(), verifyUserCompany, put);
+router.delete("/:id", admin(), verifyUserCompany, deleteUser);
 router.post("/:userId/projects/:projectId", admin(), createUserProject);
 router.delete("/:userId/projects/:projectId", superadmin(), deleteUserProject);
 


### PR DESCRIPTION
Routes were misplaced. Which means that `/:id` always caught `/self`, so I moved the `/self` route before the `/:id` one.
